### PR TITLE
Add OtterTuneServerUrl parameter to agent fargate stack to make testing easier

### DIFF
--- a/aws/agent_fargate.yaml
+++ b/aws/agent_fargate.yaml
@@ -60,6 +60,11 @@ Parameters:
       - "true"
       - "false"
     Default: "false"
+  OtterTuneServerURL:
+    Description: >-
+      The URL for OtterTune used by the agent for sending monitoring data. DO NOT CHANGE!
+    Type: String
+    Default: "https://api.ottertune.com"
 
 Conditions:
   CreateCluster: !Equals
@@ -155,6 +160,8 @@ Resources:
                   - Name: OPENSSL_CONF
                     Value: /usr/lib/ssl/openssl_cipher1.cnf
                   - !Ref AWS::NoValue
+                - Name: OTTERTUNE_OVERRIDE_SERVER_URL
+                  Value: !Ref OtterTuneServerURL
               Essential: true
               LogConfiguration:
                 LogDriver: awslogs


### PR DESCRIPTION
# What
This will allow different OT environments to override the server URL.


# Background



# Test Plan
Locally test with cloudformation stack.

