### PR TITLE
Update agent_fargate.yaml

### DIFF
--- a/aws/agent_fargate.yaml
+++ b/aws/agent_fargate.yaml
@@ -35,7 +35,7 @@ Parameters:
     Description: OtterTune provided identifier for your organization.
     Type: String
   PostgresDBName:
-    Description: Name of Postgres database. Leave blank for non postgres databases.
+    Description: Name of Postgres database (default value is postgres). You can leave this blank if the default postgres database exists.
     Type: String
     Default: ""
   Image:


### PR DESCRIPTION
# What

Updates the PostgresDBName parameter to point out that it is not required for most Postgres installs. 

# Background

This streamlines the onboarding process, almost all users should have the default postgres database in their instance.  

# Test Plan

N/A