### PR TITLE
update log id

### DIFF
--- a/aws/agent_fargate.yaml
+++ b/aws/agent_fargate.yaml
@@ -176,8 +176,8 @@ Resources:
       Type: AWS::Logs::LogGroup
       Properties:
         LogGroupName: !Sub
-          - ecs/ottertune-agent/${DBIdentifier}
-          - { DBIdentifier: !Ref DBIdentifier}
+          - ecs/ottertune-agent/${DBKey}
+          - { DBKey: !Ref DBKey}
 
     AgentTaskDefintion:
         Type: AWS::ECS::TaskDefinition


### PR DESCRIPTION
# What

Make log group name unique even for same database in different environments.

# Background
Right now, we cannot deploy agent for the same database with cloudformation in different environments (prod, dev, staging) because the log name is not unique 



# Test Plan

